### PR TITLE
fixed problem when loading CV (trajectory) files, where there are mor…

### DIFF
--- a/src/emus/usutils.py
+++ b/src/emus/usutils.py
@@ -248,7 +248,7 @@ def data_from_meta(filepath, dim, T=DEFAULT_T, k_B=DEFAULT_K_B, nsig=None, perio
     # Load in the trajectories into the cv space
     trajs = []
     for i, trajloc in enumerate(trajlocs):
-        trajs.append(np.loadtxt(trajloc)[:, 1:])
+        trajs.append(np.loadtxt(trajloc)[:, 1:+dim])
 
     # Calculate psi values
     psis = []


### PR DESCRIPTION
…e columns than time + number of dimensions. still assumes data starts at the second column